### PR TITLE
Added bam and bai to clinical output.

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -227,7 +227,9 @@ rule freebayes:
 rule copy_files:
     input:
         f'{config["output"]}/vcf_modifications_done.txt',
-        expand(f'{config["output"]}/consensus/medaka/{{sample}}.{{ref}}', sample=NAMES, ref=REF)
+        expand(f'{config["output"]}/consensus/medaka/{{sample}}.{{ref}}', sample=NAMES, ref=REF),
+        expand(f'{config["output"]}/samtools/{{sample}}.{{ref}}.bam', sample=NAMES, ref=REF),
+        expand(f'{config["output"]}/samtools/{{sample}}.{{ref}}.bam.bai', sample=NAMES, ref=REF)
     output:
         f'{config["output"]}/copy_files_done.txt'
     params:

--- a/workflow/scripts/copy_files.py
+++ b/workflow/scripts/copy_files.py
@@ -3,6 +3,7 @@
 import pandas as pd
 import os
 import yaml
+import shutil
 
 
 def copy_files():
@@ -25,6 +26,12 @@ def copy_files():
         consensus_in = f'{output}/consensus/medaka/{read_id}.{ref}/consensus.fasta'
         consensus_out = f'{output}/clinic/{read_id}.{ref}.fa'
 
+        bam_in = f'{output}/samtools/{read_id}.{ref}.bam'
+        bam_out = f'{output}/clinic/{read_id}.{ref}.bam'
+
+        bai_in = f'{output}/samtools/{read_id}.{ref}.bam.bai'
+        bai_out = f'{output}/clinic/{read_id}.{ref}.bam.bai'
+
         os.makedirs(f'{output}/clinic', exist_ok=True)
 
         # Change headers of consensus files and write to output folder
@@ -34,6 +41,10 @@ def copy_files():
                     out_fa.write(f'>{read_id}.{ref}\n')
                 else:
                     out_fa.write(line)
+
+        # Copy BAM and BAI files to the output folder
+        shutil.copy(bam_in, bam_out)
+        shutil.copy(bai_in, bai_out)
 
     with open(f'{output}/copy_files_done.txt', 'w') as f:
         f.write('All files were copied to the output folder!')


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @daniel-e-schmidt 

### The What
Added bam and bai files to output "clinical".

### The Why
The clinic wants the files to do their own checks using IGV.

### The How
* Added bam and bai files to copy_files.py
* Added bam and bai files to rule copy_files in the Snakefile.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
Run workflow on test files

### Expected outcome
That bam and bai files are written to output folder "clinic".

## Verifications
- [x] Code reviewed by @daniel-e-schmidt 
- [x] Code tested by @daniel-e-schmidt 
