### PR TITLE
Fix to empty series causing crash in qc.

### DIFF
--- a/workflow/scripts/vcf_modification.py
+++ b/workflow/scripts/vcf_modification.py
@@ -244,8 +244,9 @@ for read_id, ref in samples.items():
         qual_val = [float(x.strip()) for x in qual_val if x.strip() != '__']
 
         if not qual_val or all(x <= 1 for x in qual_val):
-            return pd.Series(dtype='float64')
-        
+            #return pd.Series(dtype='float64')
+            row['qc_pass'] = "NA"
+            return row
         # Check if any qual value <= 30 and assign True, False
         if any(x <= 30 for x in qual_val):
             row['qc_pass'] = "False"

--- a/workflow/scripts/vcf_modification.py
+++ b/workflow/scripts/vcf_modification.py
@@ -244,9 +244,9 @@ for read_id, ref in samples.items():
         qual_val = [float(x.strip()) for x in qual_val if x.strip() != '__']
 
         if not qual_val or all(x <= 1 for x in qual_val):
-            #return pd.Series(dtype='float64')
             row['qc_pass'] = "NA"
             return row
+        
         # Check if any qual value <= 30 and assign True, False
         if any(x <= 30 for x in qual_val):
             row['qc_pass'] = "False"


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @daniel-e-schmidt 

### The What
Fixed issue where the return of an empty series caused an issue with moving the qc_pass column causing the pipeline to crash.

### The Why
An empty series could not be moved out using ```df.pop```.

### The How
By setting and empty qc_pass row to NA the issue was resolved:  ```row['qc_pass'] = "NA"```.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
Running the pipeline on samples that caused a crash no longer crashes the pipeline.

### Expected outcome
* The pipeline not crashing and output looking as It was before.
* No changes in the contents of the ```qc.csv``` file.

## Verifications
- [x] Code reviewed by @daniel-e-schmidt 
- [x] Code tested by @daniel-e-schmidt
