### PR TITLE
Filter out rows where all three QC values are very poor/non-existent.

### DIFF
--- a/workflow/scripts/vcf_modification.py
+++ b/workflow/scripts/vcf_modification.py
@@ -243,6 +243,7 @@ for read_id, ref in samples.items():
         qual_val = row['QUAL'].split(';')
         qual_val = [float(x.strip()) for x in qual_val if x.strip() != '__']
 
+        # If all qual values are either non-existent or <= 1 and assign NA
         if not qual_val or all(x <= 1 for x in qual_val):
             row['qc_pass'] = "NA"
             return row
@@ -254,7 +255,9 @@ for read_id, ref in samples.items():
             row['qc_pass'] = "True"
         return row
 
+    # Filter based on the QUAL values
     aa_data_df = aa_data_df.apply(qual_check, axis=1).dropna(how='all')    # Filter using the qual_check function
+    aa_data_df = aa_data_df[aa_data_df['qc_pass'] != "NA"]    # Drop rows where all qual values are either non-existent or <= 1
     
     # Move qc_pass column to the end of the df
     qc = aa_data_df.pop('qc_pass')


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @daniel-e-schmidt 

### The What
Filter out rows where all three QC values are very poor/non-existent.

### The Why
The fix in https://github.com/ClinicalGenomicsGBG/hbv_nano/pull/6 caused an issue with all amino acid changes (even low quality ones) were included in the variant calling files. Not filtering out these rows led to cluttered variant calling files in the output where some very low quality mutations were displayed and included in the summary.

### The How
Added a filter to only include the rows where qc_pass is not NA.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
Already tested and verified by @daniel-e-schmidt. 

### Installation and initiation

### Tests

### Expected outcome
Variant calling files without rows where qc_pass is NA.

## Verifications
- [x] Code reviewed by @daniel-e-schmidt 
- [x] Code tested by @daniel-e-schmidt 
