### PR TITLE
An okay fix to an issue with some samples misleadingly passing QC of the RT region.

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -107,7 +107,7 @@ rule samtools_view:
     shell:
         """
         samtools view -F 260 {input.bam} | awk 'length($10) >= 400' | wc -l > {output.stats}   
-        samtools view -F 260 {input.bam} {wildcards.ref}:130-1161 | awk 'length($10) >= 400' | wc -l > {output.mapped_reads}
+        samtools view -F 260 {input.bam} {wildcards.ref}:600-1161 | awk 'length($10) >= 400' | wc -l > {output.mapped_reads}
         """
 
 


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @daniel-e-schmidt 

### The What
Some samples misleadingly passed QC.

### The Why
Some mostly empty reads with large N regions mapped to the beginning of the RT region. Since the QC of the RT region relies on the number of mapped reads and not their quality this led to samples passing the QC of the RT when the shouldn't have.

### The How
The way the reads of  the RT region are counted was changed to start from position 600 instead of 130. By doing this only reads that are mapping to the second half of the RT region are counted for the QC of RT. This fixes the issue.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
The change was verified by reanalysing samples that had passed QC of the RT region prior to the proposed change. After the change these samples no longer pass with significantly fewer reads mapped to the restricted RT region (600-1161).

### Expected outcome
* Fewer reads map to the restricted RT region.
* Samples that are mostly empty in RT do not pass the QC of the RT region.

## Verifications
- [x] Code reviewed by @daniel-e-schmidt
- [x] Code tested by @daniel-e-schmidt
