### PR TITLE
Fastp update

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,7 +11,7 @@ now_time: ""
 run_id: ""
 
 # Apptainer images
-fastp: "images/fastp_0.23.4.img"
+fastp: "images/fastp_1.3.3.img"
 freebayes: "images/freebayes_1.3.7.img"
 medaka: "images/medaka_1.12.0.img"
 minimap2: "images/minimap2_2.28.img"

--- a/workflow/scripts/build_images.sh
+++ b/workflow/scripts/build_images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
-apptainer build images/fastp_0.23.4.img docker://staphb/fastp
-apptainer build images/freebayes_1.3.7.img docker://staphb/freebayes
-apptainer build images/medaka_1.12.0.img docker://ontresearch/medaka
-apptainer build images/minimap2_2.28.img docker://staphb/minimap2
-apptainer build images/samtools_1.20.img docker://staphb/samtools
+apptainer build images/fastp_1.3.3.img docker://staphb/fastp:1.3.3
+apptainer build images/freebayes_1.3.7.img docker://staphb/freebayes:1.3.7
+apptainer build images/medaka_1.12.0.img docker://ontresearch/medaka:1.12.0
+apptainer build images/minimap2_2.28.img docker://staphb/minimap2:2.28
+apptainer build images/samtools_1.20.img docker://staphb/samtools:1.20


### PR DESCRIPTION
## Contents
Review deadline:
2026-06-08

Main reviewer: @SannaAb 

### The What
* Updated fastp from v0.23.4 to v1.3.3.

### The Why
* A memory bug in v0.23.4 resulted in the process taking a very large amount of memory when analysing some samples. This led to the pipeline crashing.

### The How
* This update of fastp from v0.23.4 to v1.3.3 resolves the memory issues so that all samples can be analysed successfully.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
* The code has already been reviewed and tested by @daniel-e-schmidt.

### Expected outcome
* A previous run with samples causing memory issues could be analysed successfully.

## Verifications
- [x] Code reviewed by @daniel-e-schmidt 
- [x] Code tested by @daniel-e-schmidt 
- [x] Code reviewed by @SannaAb
- [ ] Code reviewed by @sysbiocoder